### PR TITLE
Added minimal go build as Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM golang:1.4-onbuild
+ENTRYPOINT ["/go/bin/app"]


### PR DESCRIPTION
Rather than download a pre-release bin or build it, it seemed simpler to pull an image for now...

Created first pass container, currently pushed to quay.io/ukhomeofficedigital/mockingj-server (for now).