### PR TITLE
Minimize Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM progrium/busybox
-RUN opkg-install wget bash
+FROM alpine:3.3
+RUN apk add --update wget bash
 RUN wget -O mockingjay-server https://github.com/quii/mockingjay-server/releases/download/1.5.2/linux_amd64_mockingjay-server --no-check-certificate
 RUN chmod +x mockingjay-server
 ENTRYPOINT ["./mockingjay-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM alpine:3.3
-RUN apk add --update wget bash
-RUN wget -O mockingjay-server https://github.com/quii/mockingjay-server/releases/download/1.5.2/linux_amd64_mockingjay-server --no-check-certificate
-RUN chmod +x mockingjay-server
+
+RUN apk add --update wget bash && \
+    wget -O mockingjay-server https://github.com/quii/mockingjay-server/releases/download/1.5.2/linux_amd64_mockingjay-server --no-check-certificate && \
+    chmod +x mockingjay-server && \
+    apk del wget bash && \
+    rm -rf /var/cache/apk/*
+
 ENTRYPOINT ["./mockingjay-server"]


### PR DESCRIPTION
Couldn't resist trying to make the Docker image even smaller. Found a few MBs:

```
docker images | grep mockingjay-server
mockingjay-server                                              clean_alpine        0e33355644f2        3 minutes ago       13.34 MB
quii/mockingjay-server                                         1.5.2               d991fa62488c        2 days ago          26.03 MB
quii/mockingjay-server                                         1.5.1               9f45e6a1fd85        6 days ago          586.4 MB
```