### PR TITLE
CheckCompatibility mode now blows up if config file does not parse correctly

### DIFF
--- a/application.go
+++ b/application.go
@@ -95,7 +95,6 @@ func (a *application) CheckCompatibility(configPath string, realURL string) erro
 }
 
 func (a *application) loadConfig() (endpoints []mockingjay.FakeEndpoint, err error) {
-
 	configData, err := a.configLoader(a.configPath)
 
 	if err != nil {
@@ -105,6 +104,9 @@ func (a *application) loadConfig() (endpoints []mockingjay.FakeEndpoint, err err
 	if newMD5 := md5.Sum(configData); newMD5 != a.yamlMD5 {
 		a.yamlMD5 = newMD5
 		endpoints, err = a.mockingjayLoader(configData)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return
 }

--- a/main.go
+++ b/main.go
@@ -12,7 +12,10 @@ func main() {
 	app := defaultApplication(config.logger)
 
 	if config.realURL != "" {
-		app.CheckCompatibility(config.configPath, config.realURL)
+		err := app.CheckCompatibility(config.configPath, config.realURL)
+		if err != nil {
+			log.Fatal(err)
+		}
 	} else {
 		svr, err := app.CreateServer(config.configPath, config.monkeyConfigPath)
 


### PR DESCRIPTION
Fixes #39

Added some error bubbling. We'll now see an error message if non-existent file passed, or permissions are restrictive, or if contents do not parse as valid YAML.

Sadly, no idea how to write tests for this.

Manually tested with:
```
# non-existent config file
rm imaginary.yaml
./mockingjay-server -config=imaginary.yaml -realURL=http://my.awesomeservice.com

# file has useless content
echo "1" > foo.yaml
./mockingjay-server -config=foo.yaml -realURL=http://my.awesomeservice.com
```