### PR TITLE
Fix Issue #52 (body limit causing duplicate warning)

### DIFF
--- a/mockingjay/fakeendpoint.go
+++ b/mockingjay/fakeendpoint.go
@@ -81,17 +81,19 @@ func generateEndpoints(data []byte, unmarshall func([]byte, interface{}) error) 
 }
 
 func findDuplicates(endpoints []FakeEndpoint) []string {
-	requests := make(map[string]int)
+	request := make(map[string]string)
+	requestHashes := make(map[string]int)
 
 	for _, e := range endpoints {
-		requests[e.Request.String()] = requests[e.Request.String()] + 1
+		request[e.Request.Hash()] = e.Request.String()
+		requestHashes[e.Request.Hash()] = requestHashes[e.Request.Hash()] + 1
 	}
 
 	var duplicates []string
 
-	for k, v := range requests {
+	for k, v := range requestHashes {
 		if v > 1 {
-			duplicates = append(duplicates, k)
+			duplicates = append(duplicates, request[k])
 		}
 	}
 

--- a/mockingjay/fakeendpoint_test.go
+++ b/mockingjay/fakeendpoint_test.go
@@ -143,6 +143,36 @@ func TestItReturnsErrorWhenRequestsAreDuplicated(t *testing.T) {
 	assert.Contains(t, err.Error(), "duplicated")
 }
 
+const duplicatedLongBodyRequest = `
+---
+ - name: Test endpoint
+   request:
+     uri: /hello
+     method: POST
+     body: '{
+       "title": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+     }'
+   response:
+     code: 200
+     body: '{"message": "hello, world"}'
+
+ - name: Duplicated test endpoint
+   request:
+     uri: /hello
+     method: POST
+     body: '{
+       "title": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+     }'
+   response:
+     code: 404
+ `
+
+func TestItReturnsErrorWhenRequestsHaveALongBodyAndAreDuplicated(t *testing.T) {
+	_, err := NewFakeEndpoints([]byte(duplicatedLongBodyRequest))
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "There were duplicated requests found [POST /hello Body: [{ \"title\": \"Lorem Ipsum is simply dummy text of th...]]")
+}
+
 const badRegex = `
 ---
 -

--- a/mockingjay/request.go
+++ b/mockingjay/request.go
@@ -1,6 +1,7 @@
 package mockingjay
 
 import (
+	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -158,6 +159,26 @@ func (r Request) String() string {
 	}
 
 	return base
+}
+
+func (r Request) Hash() string {
+	base := fmt.Sprintf("%s %s", r.Method, r.URI)
+
+	if r.Headers != nil {
+		headersAsString := stringifyMap(r.Headers)
+		base = fmt.Sprintf("%s Headers: [%s]", base, headersAsString)
+	}
+
+	if r.Form != nil {
+		headersAsString := stringifyMap(r.Form)
+		base = fmt.Sprintf("%s Form: [%s]", base, headersAsString)
+	}
+
+	if len(r.Body) > 0 {
+		base = fmt.Sprintf("%s Body: [%s]", base, r.Body)
+	}
+
+	return fmt.Sprintf("%x", sha1.Sum([]byte(base)))
 }
 
 func stringifyMap(m map[string]string) string {

--- a/mockingjay/request_test.go
+++ b/mockingjay/request_test.go
@@ -95,7 +95,7 @@ func TestItSendsForms(t *testing.T) {
 	assert.Equal(t, expectedBody, rec.Body.String())
 }
 
-func TestItHasPrettyString(t *testing.T) {
+func TestItHasPrettyStringAndHash(t *testing.T) {
 	mapOfThings := make(map[string]string)
 	mapOfThings["A"] = "B"
 
@@ -104,6 +104,7 @@ func TestItHasPrettyString(t *testing.T) {
 	tests := []struct {
 		Request        Request
 		ExpectedString string
+		ExpectedHash   string
 	}{
 		{
 			Request: Request{
@@ -111,6 +112,7 @@ func TestItHasPrettyString(t *testing.T) {
 				Method: http.MethodGet,
 			},
 			ExpectedString: "GET /hello-world",
+			ExpectedHash:   "04e0e523f5073b5a242a8177a30dfb158325724f",
 		},
 		{
 			Request: Request{
@@ -119,6 +121,7 @@ func TestItHasPrettyString(t *testing.T) {
 				Headers: mapOfThings,
 			},
 			ExpectedString: "GET /hello-world Headers: [A->B]",
+			ExpectedHash:   "a3ec00716bcfb498e477e05791b0b1a7241e117e",
 		},
 		{
 			Request: Request{
@@ -127,14 +130,16 @@ func TestItHasPrettyString(t *testing.T) {
 				Form:   mapOfThings,
 			},
 			ExpectedString: "GET /hello-world Form: [A->B]",
+			ExpectedHash:   "7adb665c90fc7de541911d5a3e54a082f8672f09",
 		},
 		{
 			Request: Request{
 				URI:    "/hello-world",
-				Method: http.MethodGet,
+				Method: http.MethodPost,
 				Body:   longBody,
 			},
-			ExpectedString: "GET /hello-world Body: [Lorem ipsum dolor sit amet, consectetur adipiscing...]",
+			ExpectedString: "POST /hello-world Body: [Lorem ipsum dolor sit amet, consectetur adipiscing...]",
+			ExpectedHash:   "717940029370135c2fff785a2567715f36a266f8",
 		},
 		{
 			Request: Request{
@@ -143,9 +148,11 @@ func TestItHasPrettyString(t *testing.T) {
 				Body:   "short stuff",
 			},
 			ExpectedString: "GET /hello-world Body: [short stuff]",
+			ExpectedHash:   "c6997cc3b3973d28e3da221e17c03ef23fdca54f",
 		},
 	}
 	for _, test := range tests {
 		assert.Equal(t, test.ExpectedString, test.Request.String())
+		assert.Equal(t, test.ExpectedHash, test.Request.Hash())
 	}
 }


### PR DESCRIPTION
This PR fixes issue #52 .

I was able to ensure the project builds and tests pass with `./build-app.sh`.

I was unable to build the front-end with `./build.sh` due to "max stack size" error with npm (which I'm sure yarn would resolve) and some randomness with "go-bindata" where it looks like the project is no longer owned by the same owner (see https://github.com/jteeuwen/go-bindata/issues/5).