### PR TITLE
feat(file-polling): add ability to disable file polling

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -2,21 +2,22 @@ package main
 
 import (
 	"bytes"
-	"github.com/quii/mockingjay-server/mockingjay"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/quii/mockingjay-server/mockingjay"
+	"github.com/stretchr/testify/assert"
 )
 
 const testYAMLPath = "examples/example.yaml"
 
 func TestHeadersArentTooStrict(t *testing.T) {
 	app, _ := buildMJ(t, "examples/issue42.yaml")
-	failSvr, _ := app.CreateServer("", false)
+	failSvr, _ := app.CreateServer("", false, false)
 	svr := httptest.NewServer(failSvr)
 	defer svr.Close()
 
@@ -123,7 +124,7 @@ func TestANewEndpointCanBeAdded(t *testing.T) {
 func buildMJ(t *testing.T, config string) (app *application, mjServer http.Handler) {
 	t.Helper()
 	app = defaultApplication(log.New(ioutil.Discard, "", 0), mockingjay.DefaultHTTPTimeoutSeconds, config)
-	svr, err := app.CreateServer("", false)
+	svr, err := app.CreateServer("", false, false)
 
 	if err != nil {
 		t.Fatal("Couldn't load MJ config from ", config)

--- a/application_test.go
+++ b/application_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 
 	"fmt"
-	"github.com/quii/mockingjay-server/mockingjay"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http/httptest"
+
+	"github.com/quii/mockingjay-server/mockingjay"
+	"github.com/stretchr/testify/assert"
 )
 
 const someMonkeyConfigString = "Hello, world"
@@ -47,7 +48,7 @@ func TestItFailsWhenTheConfigFileCantBeLoaded(t *testing.T) {
 	app.configLoader = failingIOUtil()
 	app.configPath = "mockingjay config path"
 
-	_, err := app.CreateServer("", false)
+	_, err := app.CreateServer("", false, false)
 
 	assert.NotNil(t, err)
 	assert.Equal(t, err, errIOError)
@@ -61,7 +62,7 @@ func TestItFailsWhenTheConfigIsInvalid(t *testing.T) {
 	app := testApplication()
 	app.mockingjayLoader = failingMockingjayLoader
 
-	_, err := app.CreateServer("", false)
+	_, err := app.CreateServer("", false, false)
 
 	assert.NotNil(t, err, "Didnt get an error when the mockingjay config failed to load")
 	assert.Equal(t, err, errMJLoaderError)
@@ -80,7 +81,7 @@ func TestCompatFailsWhenConfigIsInvalid(t *testing.T) {
 func TestItFailsWhenTheMonkeyConfigIsInvalid(t *testing.T) {
 	app := testApplication()
 
-	_, err := app.CreateServer("monkey config path", false)
+	_, err := app.CreateServer("monkey config path", false, false)
 
 	assert.NotNil(t, err, "Didnt get an error when the monkey config failed to load")
 	assert.Equal(t, err, errMonkeyLoadError)

--- a/config.go
+++ b/config.go
@@ -16,11 +16,13 @@ type appConfig struct {
 	realURL          string
 	httpTimeout      time.Duration
 	debugMode        bool
+	disablePolling   bool
 }
 
 func loadConfig() *appConfig {
 	port := flag.Int("port", 9090, "Port to listen on")
 	debug := flag.Bool("debug", false, "Print debug statements")
+	disablePolling := flag.Bool("disable-polling", false, "Disable file change polling")
 	configPath := flag.String("config", "", "Path to config YAML")
 	httpTimeout := flag.Int("timeout", 5, "Optional: HTTP timeout when performing CDC")
 	monkeyConfigPath := flag.String("monkeyConfig", "", "Optional: Set this to add some monkey business")
@@ -36,6 +38,7 @@ func loadConfig() *appConfig {
 		realURL:          *realURL,
 		httpTimeout:      time.Duration(*httpTimeout),
 		debugMode:        *debug,
+		disablePolling:   *disablePolling,
 	}
 
 	if i, err := strconv.Atoi(os.Getenv("PORT")); err == nil {

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 			log.Fatal(err)
 		}
 	} else {
-		svr, err := app.CreateServer(config.monkeyConfigPath, config.debugMode)
+		svr, err := app.CreateServer(config.monkeyConfigPath, config.debugMode, config.disablePolling)
 
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Add ability to disable file polling:

Example:
```sh
mockingjay-server -config=examples/example.yaml -disable-polling
```